### PR TITLE
Fix Spotify Searching

### DIFF
--- a/search4.py
+++ b/search4.py
@@ -118,7 +118,7 @@ print(color.BOLD + color.RED + "\n::::::::::::::::::::::::::::::::::::::::::::::
 print(color.BOLD + color.WHITE + color.UNDER + "Others:\n" + color.END)
 result("https://www.wikipedia.org/wiki/User:","Wikipedia",username)
 result("https://buzzfeed.com/","Buzzfeed",username)
-result("https://open.spotify.com/user/{}","Spotify",username)
+result("https://open.spotify.com/user/","Spotify",username)
 result("https://soundcloud.com/","SoundCloud",username)
 result("https://www.crunchyroll.com/user/","Crunchyroll",username)
 


### PR DESCRIPTION
URL for Spotify search didn't match the structure for a Spotify user page since there is an extra '{}' at the end.  I have removed this.